### PR TITLE
Fix sanitized query length

### DIFF
--- a/server/src/__tests__/helpers/file.ts
+++ b/server/src/__tests__/helpers/file.ts
@@ -3,24 +3,16 @@ import path from "path"
 import { URI } from "vscode-languageserver"
 
 
-export function getSampleFileResource(file: string): URI {
-  return `file://${path.join(sampleDirPath(), file)}`
-}
-
-export function getDefinitionFileResource(file: string): URI {
-  return `file://${path.join(definitionsDirPath(), file)}`
-}
-
-export function getQueryFileResource(file: string): URI {
-  return `file://${path.join(queryDirPath(), file)}`
-}
-
 export type LoadFileOptions = {
   skipDisableComment: boolean,
 }
 
 export const DEFAULT_LOAD_FILE_OPTIONS = {
   skipDisableComment: false,
+}
+
+export function getSampleFileResource(file: string): URI {
+  return `file://${path.join(sampleDirPath(), file)}`
 }
 
 export function loadSampleFile(
@@ -36,46 +28,10 @@ export function loadSampleFile(
   }
 }
 
-export function loadDefinitionFile(
-  filename: string,
-  options: LoadFileOptions = DEFAULT_LOAD_FILE_OPTIONS,
-): string {
-  const fileText = readFileSync(path.join(definitionsDirPath(), filename)).toString()
-  if (options.skipDisableComment) {
-    return skipDisableComment(fileText)
-  }
-  else {
-    return fileText
-  }
-}
-
-export function loadQueryFile(
-  filename: string,
-  options: LoadFileOptions = DEFAULT_LOAD_FILE_OPTIONS,
-): string {
-  const fileText = readFileSync(path.join(queryDirPath(), filename)).toString()
-  if (options.skipDisableComment) {
-    return skipDisableComment(fileText)
-  }
-  else {
-    return fileText
-  }
-}
-
-function skipDisableComment(fileText: string): string {
-  return fileText.split("\n").slice(1).join("\n")
-}
-
 function sampleDirPath(): string {
   return path.join(__dirname, "..", "__fixtures__")
 }
 
-
-function definitionsDirPath(): string {
-  return path.join(__dirname, "..", "__fixtures__", "definitions")
-}
-
-
-function queryDirPath(): string {
-  return path.join(__dirname, "..", "__fixtures__", "queries")
+function skipDisableComment(fileText: string): string {
+  return fileText.split("\n").slice(1).join("\n")
 }

--- a/server/src/__tests__/helpers/file.ts
+++ b/server/src/__tests__/helpers/file.ts
@@ -3,6 +3,10 @@ import path from "path"
 import { URI } from "vscode-languageserver"
 
 
+export function getSampleFileResource(file: string): URI {
+  return `file://${path.join(sampleDirPath(), file)}`
+}
+
 export function getDefinitionFileResource(file: string): URI {
   return `file://${path.join(definitionsDirPath(), file)}`
 }
@@ -17,6 +21,19 @@ export type LoadFileOptions = {
 
 export const DEFAULT_LOAD_FILE_OPTIONS = {
   skipDisableComment: false,
+}
+
+export function loadSampleFile(
+  filename: string,
+  options: LoadFileOptions = DEFAULT_LOAD_FILE_OPTIONS,
+): string {
+  const fileText = readFileSync(path.join(sampleDirPath(), filename)).toString()
+  if (options.skipDisableComment) {
+    return skipDisableComment(fileText)
+  }
+  else {
+    return fileText
+  }
 }
 
 export function loadDefinitionFile(
@@ -48,6 +65,11 @@ export function loadQueryFile(
 function skipDisableComment(fileText: string): string {
   return fileText.split("\n").slice(1).join("\n")
 }
+
+function sampleDirPath(): string {
+  return path.join(__dirname, "..", "__fixtures__")
+}
+
 
 function definitionsDirPath(): string {
   return path.join(__dirname, "..", "__fixtures__", "definitions")

--- a/server/src/__tests__/helpers/textDocuments.ts
+++ b/server/src/__tests__/helpers/textDocuments.ts
@@ -1,7 +1,9 @@
 import { TextDocuments, URI } from "vscode-languageserver"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
-import { getSampleFileResource, loadSampleFile } from "./file"
+import {
+  DEFAULT_LOAD_FILE_OPTIONS, getSampleFileResource, LoadFileOptions, loadSampleFile,
+} from "./file"
 
 
 export class TestTextDocuments extends TextDocuments<TextDocument> {
@@ -20,13 +22,13 @@ export class TestTextDocuments extends TextDocuments<TextDocument> {
   }
 }
 
-export function makeTextDocument(
+export function makeSampleTextDocument(
   file: string,
-  options: { ignoreDesableFlag: boolean } = { ignoreDesableFlag: false },
+  options: LoadFileOptions = DEFAULT_LOAD_FILE_OPTIONS,
 ): TextDocument {
   let context = loadSampleFile(file)
 
-  if (options.ignoreDesableFlag) {
+  if (options.skipDisableComment) {
     context = context.split("\n").slice(1).join("\n")
   }
 

--- a/server/src/__tests__/helpers/textDocuments.ts
+++ b/server/src/__tests__/helpers/textDocuments.ts
@@ -1,6 +1,8 @@
 import { TextDocuments, URI } from "vscode-languageserver"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
+import { getSampleFileResource, loadSampleFile } from "./file"
+
 
 export class TestTextDocuments extends TextDocuments<TextDocument> {
   documents = new Map<URI, TextDocument>()
@@ -16,4 +18,22 @@ export class TestTextDocuments extends TextDocuments<TextDocument> {
   set(document: TextDocument): void {
     this.documents.set(document.uri, document)
   }
+}
+
+export function makeTextDocument(
+  file: string,
+  options: { ignoreDesableFlag: boolean } = { ignoreDesableFlag: false },
+): TextDocument {
+  let context = loadSampleFile(file)
+
+  if (options.ignoreDesableFlag) {
+    context = context.split("\n").slice(1).join("\n")
+  }
+
+  return TextDocument.create(
+    getSampleFileResource(file),
+    "postgres",
+    0,
+    context,
+  )
 }

--- a/server/src/postgres/parameters/defaultParameters.test.ts
+++ b/server/src/postgres/parameters/defaultParameters.test.ts
@@ -1,0 +1,40 @@
+import { NullLogger } from "vscode-languageserver"
+
+import { makeTextDocument } from "@/__tests__/helpers/textDocuments"
+import { neverReach } from "@/utilities/neverReach"
+
+import {
+  getDefaultQueryParameterInfo, sanitizeFileWithDefaultQueryParameters,
+} from "./defaultParameters"
+
+export type DefaultQueryParametersInfo = {
+  type: "default",
+  queryParameters: string[],
+  queryParameterPattern: string
+}
+
+describe("Default Query Parameter Tests", () => {
+  describe("Keyword Parameter Tests", function () {
+    it("Check sanitized query length.", async () => {
+      const document = makeTextDocument(
+        "queries/correct_query_with_default_keyword_parameter.pgsql",
+        { ignoreDesableFlag: true },
+      )
+      const queryParametersInfo = getDefaultQueryParameterInfo(
+        document, /:[A-Za-z_][A-Za-z0-9_]*/.source, NullLogger,
+      )
+
+      expect(queryParametersInfo).toBeTruthy()
+      if (queryParametersInfo === null) neverReach()
+
+      expect(queryParametersInfo?.queryParameters).toStrictEqual([":id", ":names"])
+
+      const originalText = document.getText()
+      const [sanitizedText] = sanitizeFileWithDefaultQueryParameters(
+        originalText, queryParametersInfo, NullLogger,
+      )
+
+      expect(sanitizedText.length).toEqual(originalText.length)
+    })
+  })
+})

--- a/server/src/postgres/parameters/defaultParameters.test.ts
+++ b/server/src/postgres/parameters/defaultParameters.test.ts
@@ -1,6 +1,6 @@
 import { NullLogger } from "vscode-languageserver"
 
-import { makeTextDocument } from "@/__tests__/helpers/textDocuments"
+import { makeSampleTextDocument } from "@/__tests__/helpers/textDocuments"
 import { neverReach } from "@/utilities/neverReach"
 
 import {
@@ -16,9 +16,9 @@ export type DefaultQueryParametersInfo = {
 describe("Default Query Parameter Tests", () => {
   describe("Keyword Parameter Tests", function () {
     it("Check sanitized query length.", async () => {
-      const document = makeTextDocument(
+      const document = makeSampleTextDocument(
         "queries/correct_query_with_default_keyword_parameter.pgsql",
-        { ignoreDesableFlag: true },
+        { skipDisableComment: true },
       )
       const queryParametersInfo = getDefaultQueryParameterInfo(
         document, /:[A-Za-z_][A-Za-z0-9_]*/.source, NullLogger,

--- a/server/src/postgres/parameters/defaultParameters.ts
+++ b/server/src/postgres/parameters/defaultParameters.ts
@@ -4,6 +4,8 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 import { escapeRegex } from "@/utilities/regex"
 import { getFirstLine, getTextAfterFirstLine } from "@/utilities/text"
 
+import { makePositionalParamter } from "./helpers"
+
 export type DefaultQueryParametersInfo = {
   type: "default",
   queryParameters: string[],
@@ -52,7 +54,7 @@ export function sanitizeFileWithDefaultQueryParameters(
   for (const [index, parameter] of Array.from(queryParameters.values()).entries()) {
     fileText = fileText.replace(
       new RegExp(escapeRegex(parameter), "g"),
-      `$${index + 1}`,
+      makePositionalParamter(index, parameter),
     )
   }
 

--- a/server/src/postgres/parameters/helpers.ts
+++ b/server/src/postgres/parameters/helpers.ts
@@ -1,0 +1,15 @@
+import { uinteger } from "vscode-languageserver"
+
+export function makePositionalParamter(
+  index: uinteger,
+  keywordParameter: string,
+): string {
+  let positionalParameter = `$${index + 1}`
+
+  // Add padding to maintain query length
+  positionalParameter += " ".repeat(
+    Math.max(0, keywordParameter.length - positionalParameter.length),
+  )
+
+  return positionalParameter
+}

--- a/server/src/postgres/parameters/keywordParameters.test.ts
+++ b/server/src/postgres/parameters/keywordParameters.test.ts
@@ -1,6 +1,6 @@
 import { NullLogger } from "vscode-languageserver"
 
-import { makeTextDocument } from "@/__tests__/helpers/textDocuments"
+import { makeSampleTextDocument } from "@/__tests__/helpers/textDocuments"
 import { neverReach } from "@/utilities/neverReach"
 
 import {
@@ -16,7 +16,7 @@ export type DefaultQueryParametersInfo = {
 describe("Keyword Query Parameter Tests", () => {
   describe("Keyword Parameter Tests", function () {
     it("Check sanitized query length.", async () => {
-      const document = makeTextDocument(
+      const document = makeSampleTextDocument(
         "queries/correct_query_with_keyword_parameter.pgsql",
       )
       const queryParametersInfo = getKeywordQueryParameterInfo(

--- a/server/src/postgres/parameters/keywordParameters.test.ts
+++ b/server/src/postgres/parameters/keywordParameters.test.ts
@@ -1,0 +1,39 @@
+import { NullLogger } from "vscode-languageserver"
+
+import { makeTextDocument } from "@/__tests__/helpers/textDocuments"
+import { neverReach } from "@/utilities/neverReach"
+
+import {
+  getKeywordQueryParameterInfo, sanitizeFileWithKeywordQueryParameters,
+} from "./keywordParameters"
+
+export type DefaultQueryParametersInfo = {
+  type: "default",
+  queryParameters: string[],
+  queryParameterPattern: string
+}
+
+describe("Keyword Query Parameter Tests", () => {
+  describe("Keyword Parameter Tests", function () {
+    it("Check sanitized query length.", async () => {
+      const document = makeTextDocument(
+        "queries/correct_query_with_keyword_parameter.pgsql",
+      )
+      const queryParametersInfo = getKeywordQueryParameterInfo(
+        document, "@{keyword}", NullLogger,
+      )
+
+      expect(queryParametersInfo).toBeTruthy()
+      if (queryParametersInfo === null) neverReach()
+
+      expect(queryParametersInfo?.keywordParameters).toStrictEqual(["@id", "@names"])
+
+      const originalText = document.getText()
+      const [sanitizedText] = sanitizeFileWithKeywordQueryParameters(
+        originalText, queryParametersInfo, NullLogger,
+      )
+
+      expect(sanitizedText.length).toEqual(originalText.length)
+    })
+  })
+})

--- a/server/src/postgres/parameters/keywordParameters.ts
+++ b/server/src/postgres/parameters/keywordParameters.ts
@@ -4,6 +4,8 @@ import { TextDocument } from "vscode-languageserver-textdocument"
 import { escapeRegex } from "@/utilities/regex"
 import { getFirstLine, getTextAfterFirstLine } from "@/utilities/text"
 
+import { makePositionalParamter } from "./helpers"
+
 export type KeywordQueryParametersInfo = {
   type: "keyword",
   keywordParameters: string[],
@@ -14,7 +16,7 @@ export class KeywordQueryParameterPatternNotDefinedError extends Error {
   constructor() {
     super(
       "'plpgsqlLanguageServer.keywordQueryParameterPattern'"
-      +" does not set in the settings.",
+      + " does not set in the settings.",
     )
     this.name = "KeywordQueryParameterPatternNotDefinedError"
   }
@@ -68,7 +70,7 @@ export function getKeywordQueryParameterInfo(
         )
         keywordParameters = Array.from(
           new Set(
-            [...getTextAfterFirstLine(document) .matchAll(keywordRegExp)]
+            [...getTextAfterFirstLine(document).matchAll(keywordRegExp)]
               .map((found) => found[0]),
           ),
         )
@@ -89,14 +91,14 @@ export function sanitizeFileWithKeywordQueryParameters(
   fileText: string,
   queryParameterInfo: KeywordQueryParametersInfo,
   _logger: Logger,
-) : [string, uinteger] {
+): [string, uinteger] {
   const keywordParameters = new Set(queryParameterInfo.keywordParameters)
   for (
     const [index, keywordParameter] of Array.from(keywordParameters.values()).entries()
   ) {
     fileText = fileText.replace(
       new RegExp(escapeRegex(keywordParameter), "g"),
-      `$${index + 1}`,
+      makePositionalParamter(index, keywordParameter),
     )
   }
 

--- a/server/src/postgres/parsers/getDefinitions.test.ts
+++ b/server/src/postgres/parsers/getDefinitions.test.ts
@@ -1,7 +1,7 @@
 import { parseQuery } from "libpg-query"
 import { Range, uinteger } from "vscode-languageserver"
 
-import { loadDefinitionFile } from "@/__tests__/helpers/file"
+import { loadSampleFile } from "@/__tests__/helpers/file"
 
 import {
   getFunctionDefinitions,
@@ -13,21 +13,21 @@ import { Statement } from "./statement"
 
 test.each([
   [
-    "tables/companies.pgsql",
+    "definitions/tables/companies.pgsql",
     Array(2).fill(Range.create(2, 13, 2, 22)),
   ],
   [
-    "tables/public_users.pgsql",
+    "definitions/tables/public_users.pgsql",
     Array(2).fill(Range.create(2, 13, 2, 25)),
   ],
   [
-    "tables/campaign_participants.pgsql",
+    "definitions/tables/campaign_participants.pgsql",
     [Range.create(2, 13, 2, 34)],
   ],
 ])(
   'getTableDefinitions <- "%s"',
   async (file, expected) => {
-    const fileText = loadDefinitionFile(file)
+    const fileText = loadSampleFile(file)
     const statements = getTableDefinitions(
       fileText, await getStmtement(fileText, 1), `file://${file}`, "public",
     )
@@ -42,20 +42,20 @@ test.each([
 
 test.each([
   [
-    "views/deleted_users.pgsql",
+    "definitions/views/deleted_users.pgsql",
     Array(2).fill(Range.create(2, 12, 2, 25)),
   ],
   [
-    "views/public_deleted_users.pgsql",
+    "definitions/views/public_deleted_users.pgsql",
     Array(2).fill(Range.create(2, 12, 2, 32)),
   ],
   [
-    "views/campaign_deleted_participants.pgsql",
+    "definitions/views/campaign_deleted_participants.pgsql",
     [Range.create(2, 12, 2, 41)],
   ],
 ])(
   'getViewDefinitions <- "%s"', async (file, expected) => {
-    const fileText = loadDefinitionFile(file)
+    const fileText = loadSampleFile(file)
     const statements = getViewDefinitions(
       fileText, await getStmtement(fileText, 1), `file://${file}`, "public",
     )
@@ -70,12 +70,12 @@ test.each([
 
 test.each([
   [
-    "types/type_user.pgsql",
+    "definitions/types/type_user.pgsql",
     Array(2).fill(Range.create(2, 12, 2, 21)),
   ],
 ])(
   'getTypeDefinitions <- "%s"', async (file, expected) => {
-    const fileText = loadDefinitionFile(file)
+    const fileText = loadSampleFile(file)
     const statements = getTypeDefinitions(
       fileText, await getStmtement(fileText, 1), `file://${file}`, "public",
     )
@@ -90,13 +90,13 @@ test.each([
 
 test.each([
   [
-    "stored/function_correct.pgsql",
+    "definitions/stored/function_correct.pgsql",
     Array(2).fill(Range.create(2, 16, 2, 32)),
   ],
 ])(
   'getFunctionDefinitions <- "%s"',
   async (file, expected) => {
-    const fileText = loadDefinitionFile(file)
+    const fileText = loadSampleFile(file)
     const statements = getFunctionDefinitions(
       fileText, await getStmtement(fileText, 1), `file://${file}`, "public",
     )

--- a/server/src/services/definition.test.ts
+++ b/server/src/services/definition.test.ts
@@ -5,7 +5,7 @@ import {
 } from "vscode-languageserver"
 import { TextDocument } from "vscode-languageserver-textdocument"
 
-import { getDefinitionFileResource } from "@/__tests__/helpers/file"
+import { getSampleFileResource } from "@/__tests__/helpers/file"
 import { setupTestServer } from "@/__tests__/helpers/server"
 import { SettingsBuilder } from "@/__tests__/helpers/settings"
 import { TestTextDocuments } from "@/__tests__/helpers/textDocuments"
@@ -64,7 +64,7 @@ describe("Definition Tests", () => {
 
   describe("Definition", function () {
     it("Definition on table", async () => {
-      const documentUri = getDefinitionFileResource("tables/companies.pgsql")
+      const documentUri = getSampleFileResource("definitions/tables/companies.pgsql")
       const definition = await onDefinition(documentUri, "companies")
 
       validateDefinitionLinks(definition, [
@@ -77,7 +77,7 @@ describe("Definition Tests", () => {
     })
 
     it("Definition on table with default schema", async () => {
-      const documentUri = getDefinitionFileResource("tables/public_users.pgsql")
+      const documentUri = getSampleFileResource("definitions/tables/public_users.pgsql")
       const definition = await onDefinition(documentUri, "public.users")
 
       validateDefinitionLinks(definition, [
@@ -90,8 +90,8 @@ describe("Definition Tests", () => {
     })
 
     it("Definition on table with non-default schema", async () => {
-      const documentUri = getDefinitionFileResource(
-        "tables/campaign_participants.pgsql",
+      const documentUri = getSampleFileResource(
+        "definitions/tables/campaign_participants.pgsql",
       )
       const definition = await onDefinition(documentUri, "campaign.participants")
 
@@ -105,7 +105,7 @@ describe("Definition Tests", () => {
     })
 
     it("Definition on view", async () => {
-      const documentUri = getDefinitionFileResource("views/deleted_users.pgsql")
+      const documentUri = getSampleFileResource("definitions/views/deleted_users.pgsql")
       const definition = await onDefinition(documentUri, "deleted_users")
 
       validateDefinitionLinks(definition, [
@@ -118,7 +118,7 @@ describe("Definition Tests", () => {
     })
 
     it("Definition with language server disable comment", async () => {
-      const documentUri = getDefinitionFileResource("tables/companies.pgsql")
+      const documentUri = getSampleFileResource("definitions/tables/companies.pgsql")
       const definition = await onDefinition(
         documentUri,
         dedent`
@@ -133,7 +133,7 @@ describe("Definition Tests", () => {
     })
 
     it("Definition with language server disable block comment", async () => {
-      const documentUri = getDefinitionFileResource("tables/companies.pgsql")
+      const documentUri = getSampleFileResource("definitions/tables/companies.pgsql")
       const definition = await onDefinition(
         documentUri,
         dedent`


### PR DESCRIPTION
### What does this PR do?
Validation of a query with a keyword parameters converts the keyword parameter to a positional parameter.

This conversion changes the length of the query, so the error location will not indicate the correct position.

### What issues does this PR fix or reference?
As much as possible, padding is done so that the query length does not change to point to the correct error position.

### Is it tested? How?
Add tests.