### PR TITLE
Update: use snippet format.

### DIFF
--- a/server/src/postgres/queries/queryFunctionDefinitions.ts
+++ b/server/src/postgres/queries/queryFunctionDefinitions.ts
@@ -167,15 +167,15 @@ export function makeInsertFunctionText(
   let callArgsString = ""
   if (functionIdentityArgs.length > 0) {
     callArgsString = "\n" + functionIdentityArgs.map(
-      (arg) => {
+      (arg, index) => {
         const splitted = arg.split(" ")
         if (splitted.length === 1 || splitted[1] === '"any"') {
           // argument
-          return `  ${splitted[0]}`
+          return `  $\{${index + 1}:${splitted[0]}}`
         }
         else {
           // keyword argument
-          return `  ${splitted[0]} := ${splitted[0]}`
+          return `  ${splitted[0]} := $\{${index + 1}:${splitted[0]}}`
         }
       },
     ).join(",\n") + "\n"

--- a/server/src/services/completion.ts
+++ b/server/src/services/completion.ts
@@ -2,6 +2,7 @@ import dedent from "ts-dedent"
 import {
   CompletionItem,
   CompletionItemKind,
+  InsertTextFormat,
   Logger,
   Position,
 } from "vscode-languageserver"
@@ -185,6 +186,7 @@ async function getFunctionCompletionItems(
         data: index,
         detail: makeFunctionDefinitionText(definition),
         insertText: makeInsertFunctionText(definition),
+        insertTextFormat: InsertTextFormat.Snippet,
       }),
     )
 }
@@ -221,7 +223,8 @@ function getBuiltinFunctionCompletionItems(): CompletionItem[] {
           FUNCTION ${functionName}(value [, ...])
             LANGUAGE built-in
         `,
-        insertText: `${functionName}(value, ...)`,
+        insertText: `${functionName}($\{1:value}, $\{2:...})`,
+        insertTextFormat: InsertTextFormat.Snippet,
       }),
     ).concat(["nullif"]
       .map(
@@ -233,7 +236,8 @@ function getBuiltinFunctionCompletionItems(): CompletionItem[] {
           FUNCTION ${functionName}(value1, value2)
             LANGUAGE built-in
           `,
-          insertText: `${functionName}(value1, value2)`,
+          insertText: `${functionName}($\{1:value1}, $\{2:value2})`,
+          insertTextFormat: InsertTextFormat.Snippet,
         }),
       ))
 }


### PR DESCRIPTION
### What does this PR do?
Use snippet format completions.

### What issues does this PR fix or reference?
Arguments of the function completion does not support snippet format now. 

This PR support quickly jump to the next arguments of the function with Tab.

### Is it tested? How?
Check on sample workspace.