### PR TITLE
Keyword parameter in string regex fix

### DIFF
--- a/sample/queries/correct_query_with_ts_query_keyword_parameter.pgsql
+++ b/sample/queries/correct_query_with_ts_query_keyword_parameter.pgsql
@@ -1,0 +1,12 @@
+-- plpgsql-language-server:use-keyword-query-parameter
+
+SELECT
+  id,
+  LOWER(TS_HEADLINE('english', COALESCE(name, ''),
+    WEBSEARCH_TO_TSQUERY('english', @query), 'StartSel=<--,StopSel=-->, FragmentDelimiter=$#$')) as headline,
+  LOWER(TS_HEADLINE('english', COALESCE(name, ''),
+    WEBSEARCH_TO_TSQUERY('english', sqlc.arg('query2')), 'StartSel=<--,StopSel=-->, FragmentDelimiter=$#$')) as headline2
+FROM
+  users
+WHERE
+  id = @id;

--- a/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
+++ b/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
@@ -131,7 +131,7 @@ function sanitizeStatement(
         queryParameterInfo.queryParameterPattern.map(pattern => {
           re = makeParamPatternInStringPattern(pattern)
           statement = statement.replace(
-            re, (match) => `'${"_".repeat(match.length - 2)}'`,
+            re, (match) => `${"_".repeat(match.length)}`,
           )
         } )
 
@@ -147,7 +147,7 @@ function sanitizeStatement(
         queryParameterInfo.keywordQueryParameterPattern.map(pattern => {
           re = makeParamPatternInStringPattern(pattern)
           statement = statement.replace(
-            re, (match) => `'${"_".repeat(match.length - 2)}'`,
+            re, (match) => `${"_".repeat(match.length)}`,
           )
         })
 
@@ -178,9 +178,9 @@ function makeParamPatternInStringPattern(
   paramPattern: string,
 ): RegExp {
   return new RegExp(
-    "'.*?"
-     + paramPattern.replace("{keyword}", "[A-Za-z_][A-Za-z0-9_]*?")
-     + ".*?'",
+    "(?<=')[^']*.?"
+		+ paramPattern.replace("{keyword}", "[^']*?")
+		+ "(?='(?:[^']*'[^']*')*[^']*$)",
     "g",
   )
 }

--- a/server/src/services/validation.test.ts
+++ b/server/src/services/validation.test.ts
@@ -224,7 +224,11 @@ describe("Validate Tests", () => {
   describe("Keyword Query Parameter File Validation", function () {
     beforeEach(() => {
       const settings = new SettingsBuilder()
-        .with({ keywordQueryParameterPattern: ["@{keyword}"] })
+        .with({ keywordQueryParameterPattern: [
+          "@{keyword}",
+          "sqlc\\.arg\\s*\\('{keyword}'\\)",
+          "sqlc\\.narg\\s*\\('{keyword}'\\)",
+        ] })
         .build()
       server = setupTestServer(settings, new RecordLogger())
     })
@@ -244,6 +248,15 @@ describe("Validate Tests", () => {
 
       expect(diagnostics).toStrictEqual([])
     })
+
+
+    it("Correct query with multiple single quotes and keyword parameters", async () => {
+      const diagnostics = await validateSampleFile(
+		  "queries/correct_query_with_ts_query_keyword_parameter.pgsql",
+      )
+
+      expect(diagnostics).toStrictEqual([])
+	  })
   })
 
   describe("Multiple Statements File Validation With Keyword Parameters", function () {


### PR DESCRIPTION
### What does this PR do?

Update regex to find query parameters to work correctly when multiple strings appear in the same line

### Is it tested? How?
Yes
