### PR TITLE
analyzeOn flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,16 @@
 					"default": "public",
 					"description": "Default schema name."
 				},
+				"plpgsqlLanguageServer.analyzeOn": {
+					"scope": "resource",
+					"type": "string",
+					"enum": [
+						"save",
+						"change"
+					],
+					"default": "change",
+					"description": "Specify when to analyze files. Default: 'change'"
+				},
 				"plpgsqlLanguageServer.queryParameterPattern": {
 					"scope": "resource",
 					"type": "string",

--- a/server/src/server/handlers.ts
+++ b/server/src/server/handlers.ts
@@ -89,7 +89,10 @@ export class Handlers {
   async onDidChangeContent(
     event: TextDocumentChangeEvent<TextDocument>,
   ): Promise<void> {
-    await this.validate(event.document)
+    const settings = await this.settingsManager.get(event.document.uri)
+    if (settings.analyzeOn === "change") {
+      await this.validate(event.document)
+    }
   }
 
   async onDidClose(

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -12,6 +12,7 @@ export interface Settings {
   enableExecuteFileQueryCommand: boolean;
   workspaceValidationTargetFiles: string[];
   migrations?: MigrationsSettings;
+  analyzeOn?: "save" | "change"
 }
 
 export interface MigrationsSettings {
@@ -40,4 +41,5 @@ export const DEFAULT_SETTINGS: Settings = {
   enableExecuteFileQueryCommand: true,
   workspaceValidationTargetFiles: [],
   migrations: undefined,
+  analyzeOn:  "change",
 }


### PR DESCRIPTION
### What does this PR do?

Adds a new `analyzeOn` setting option to choose whether to analyze files on change or on save. Particularly useful when used with #58 to prevent a constant stream of migrations run against the db, which regularly show a `deadlock` error.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
