### PR TITLE
Sanitize migrations and parse comment to disable specific statement validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,4 +305,8 @@ FROM
   users
 WHERE
   name = ANY(@names);
+
+-- name: DoNotValidate :many
+-- plpgsql-language-server:disable
+SELECT * FROM inexistent_table; -- no error raised for this statement
 ```

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
 		"vscode:prepublish": "npm run build",
 		"build": "npm run clean && webpack --mode production --config ./client/webpack.config.js && webpack --mode production --config ./server/webpack.config.js",
 		"build:dev": "npm run clean && webpack --mode none --config ./client/webpack.config.js && webpack --mode none --config ./server/webpack.config.js",
+		"tsc": "tsc --noEmit --project ./tsconfig.json && npm run tsc:client && npm run tsc:server",
+		"tsc:client": "tsc --noEmit --project ./client/tsconfig.json",
+		"tsc:server": "tsc --noEmit --project ./server/tsconfig.json",
 		"compile": "tsc -b",
 		"compile:client": "tsc -b ./client/tsconfig.json",
 		"compile:server": "tsc -b ./server/tsconfig.json",
@@ -154,11 +157,6 @@
 					"default": "\\$[1-9][0-9]*",
 					"description": "Query parameter pattern. the pattern is described by regular expression."
 				},
-				"plpgsqlLanguageServer.statementSeparatorPattern": {
-					"scope": "resource",
-					"type": "string",
-					"description": "Prepared statement separator regex pattern. If set, multiple statements in a file can be analyzed. Example: '-- name:[\\s]+.*'"
-				},
 				"plpgsqlLanguageServer.keywordQueryParameterPattern": {
 					"scope": "resource",
 					"type": "array",
@@ -167,6 +165,34 @@
 					"items": {
 						"type": "string"
 					}
+				},
+				"plpgsqlLanguageServer.statements": {
+					"properties": {
+						"separatorPattern": {
+							"scope": "resource",
+							"type": "string",
+							"required": true,
+							"example": "-- name:[\\s]+.*",
+							"description": "Prepared statement separator regex pattern. If set, multiple statements in a file can be analyzed."
+						},
+						"diagnosticsLevels": {
+							"scope": "resource",
+							"type": "object",
+							"default": null,
+							"description": "Override diagnostic levels for statements.",
+							"properties": {
+								"disableFlag": {
+									"scope": "resource",
+									"type": "string",
+									"default": "ignore",
+									"description": "Set diagnostic level for the disabled validation flag."
+								}
+							}
+						}
+					},
+					"scope": "resource",
+					"type": "object",
+					"description": "If set, migrations will be applied for all analyses. If the current file is a migration file, execution will run until the previous migration."
 				},
 				"plpgsqlLanguageServer.migrations": {
 					"properties": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
 							"type": "string",
 							"required": true,
 							"example": "-- name:[\\s]+.*",
-							"description": "Prepared statement separator regex pattern. If set, multiple statements in a file can be analyzed."
+							"description": "Prepared statement separator regex pattern."
 						},
 						"diagnosticsLevels": {
 							"scope": "resource",
@@ -185,14 +185,19 @@
 									"scope": "resource",
 									"type": "string",
 									"default": "ignore",
+									"enum": [
+										"ignore",
+										"warning"
+									],
 									"description": "Set diagnostic level for the disabled validation flag."
 								}
 							}
 						}
 					},
+					"default": null,
 					"scope": "resource",
 					"type": "object",
-					"description": "If set, migrations will be applied for all analyses. If the current file is a migration file, execution will run until the previous migration."
+					"description": "If set, multiple statements in a file can be analyzed based on a separator."
 				},
 				"plpgsqlLanguageServer.migrations": {
 					"properties": {

--- a/server/src/commands/validateWorkspace.ts
+++ b/server/src/commands/validateWorkspace.ts
@@ -63,7 +63,7 @@ export async function validateFile(
           hasDiagnosticRelatedInformationCapability:
             options.hasDiagnosticRelatedInformationCapability,
           queryParameterInfo,
-          statementSeparatorPattern: settings.statementSeparatorPattern,
+          statements: settings.statements,
         },
         settings,
         logger,

--- a/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
+++ b/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
@@ -99,7 +99,7 @@ export async function queryFileSyntaxAnalysis(
       .replace(COMMIT_RE, (m) => "-".repeat(m.length))
       .replace(ROLLBACK_RE, (m) => "-".repeat(m.length))
 
-    if (DISABLE_STATEMENT_VALIDATION_RE.test(statement)) {
+    if (options.statements && DISABLE_STATEMENT_VALIDATION_RE.test(statement)) {
       if (options.statements?.diagnosticsLevels?.disableFlag === "warning") {
         warnings.push({
           range: getRange(doc, currentPosition),

--- a/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
+++ b/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
@@ -23,6 +23,11 @@ export interface SyntaxError {
   message: string;
 }
 
+export interface SyntaxWarning {
+  range: Range;
+  message: string;
+}
+
 export type SyntaxAnalysisOptions = {
   isComplete: boolean;
   queryParameterInfo: QueryParameterInfo | null;
@@ -35,7 +40,7 @@ export async function queryFileSyntaxAnalysis(
   options: SyntaxAnalysisOptions,
   settings: Settings,
   logger: Logger,
-): Promise<[SyntaxError[], SyntaxError[]]> {
+): Promise<[SyntaxError[], SyntaxWarning[]]> {
   const errors = []
   const warnings = []
   const doc = document.getText()

--- a/server/src/services/validation.test.ts
+++ b/server/src/services/validation.test.ts
@@ -259,19 +259,25 @@ describe("Validate Tests", () => {
 	  })
   })
 
-  describe("Multiple Statements File Validation With Keyword Parameters", function () {
-    beforeEach(() => {
+  describe("Statement diagnostic settings", function () {
+    it("Show warning on disabled statement if flag set", async () => {
       const settings = new SettingsBuilder()
-        .with({ keywordQueryParameterPattern: [
-          "@{keyword}",
-          "sqlc\\.arg\\('{keyword}'\\)",
-          "sqlc\\.narg\\('{keyword}'\\)",
-        ], statementSeparatorPattern: "-- name:[\\s]+.*" })
+        .with({
+          keywordQueryParameterPattern: [
+            "@{keyword}",
+            "sqlc\\.arg\\('{keyword}'\\)",
+            "sqlc\\.narg\\('{keyword}'\\)",
+          ],
+          statements: {
+            separatorPattern: "-- name:[\\s]+.*",
+            diagnosticsLevels: {
+              disableFlag: "warning",
+            },
+          },
+        })
         .build()
       server = setupTestServer(settings, new RecordLogger())
-    })
 
-    it("Correct query with multiple statements", async () => {
       const diagnostics = await validateSampleFile(
         "queries/correct_query_with_multiple_statements.pgsql",
       )
@@ -282,6 +288,28 @@ describe("Validate Tests", () => {
       // warning for disabled statement
       expect(diagnostics[0].severity).toBe(2)
       expect(diagnostics[0].message).toContain("Validation disabled")
+    })
+
+    it("Shows no diagnostic by default", async () => {
+      const settings = new SettingsBuilder()
+        .with({
+          keywordQueryParameterPattern: [
+            "@{keyword}",
+            "sqlc\\.arg\\('{keyword}'\\)",
+            "sqlc\\.narg\\('{keyword}'\\)",
+          ],
+          statements: {
+            separatorPattern: "-- name:[\\s]+.*",
+          },
+        })
+        .build()
+      server = setupTestServer(settings, new RecordLogger())
+
+      const diagnostics = await validateSampleFile(
+        "queries/correct_query_with_multiple_statements.pgsql",
+      )
+
+      expect(diagnostics).toStrictEqual([])
     })
   })
 

--- a/server/src/services/validation.test.ts
+++ b/server/src/services/validation.test.ts
@@ -285,6 +285,9 @@ describe("Validate Tests", () => {
       if (!diagnostics) {
         throw new Error("")
       }
+      if (diagnostics?.length === 0) {
+        throw new Error("")
+      }
       // warning for disabled statement
       expect(diagnostics[0].severity).toBe(2)
       expect(diagnostics[0].message).toContain("Validation disabled")

--- a/server/src/services/validation.ts
+++ b/server/src/services/validation.ts
@@ -31,7 +31,9 @@ export async function validateTextDocument(
     logger,
   )
 
-  if (diagnostics.filter(d => d.severity === DiagnosticSeverity.Error).length === 0) {
+  // TODO static analysis for statements
+  // if (diagnostics.filter(d => d.severity === DiagnosticSeverity.Error).length === 0) {
+  if (diagnostics.length === 0) {
     diagnostics = await validateStaticAnalysis(
       pgPool,
       document,

--- a/server/src/settings.ts
+++ b/server/src/settings.ts
@@ -8,11 +8,22 @@ export interface Settings {
   defaultSchema: string;
   queryParameterPattern: string | string[];
   keywordQueryParameterPattern?: string | string[];
-  statementSeparatorPattern?: string;
   enableExecuteFileQueryCommand: boolean;
   workspaceValidationTargetFiles: string[];
   migrations?: MigrationsSettings;
+  statements?: StatementsSettings;
   validateOn: "save" | "change"
+}
+
+export interface StatementsSettings {
+  diagnosticsLevels?: StatementsDiagnosticLevelSettings;
+  separatorPattern: string;
+}
+
+export type DiagnosticLevel = "ignore" | "warning";
+
+export interface StatementsDiagnosticLevelSettings {
+  disableFlag?: DiagnosticLevel;
 }
 
 export interface MigrationsSettings {
@@ -37,9 +48,9 @@ export const DEFAULT_SETTINGS: Settings = {
   defaultSchema: "public",
   queryParameterPattern: /\$[1-9][0-9]*/.source,
   keywordQueryParameterPattern: undefined,
-  statementSeparatorPattern: undefined,
   enableExecuteFileQueryCommand: true,
   workspaceValidationTargetFiles: [],
   migrations: undefined,
+  statements: undefined,
   validateOn: "change",
 }


### PR DESCRIPTION
### What does this PR do?

- (rather critical) Ensure migration files don't get actually executed by removing begin, commit and rollback.

- As a workaround for #61 (and any other bug that arises), add an option to disable statements validation in the same way as the complete file
![image](https://user-images.githubusercontent.com/71724149/203406876-03151275-b58e-48c2-be11-4f3128f4b350.png)
I believe the warning should be explicit as it is now since ideally this flag should not be used in any case and let the extension do its work



### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
