### PR TITLE
fix default value for optional migrations settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
 							"description": "Down migrations file pattern. Executed by sorted filename order."
 						},
 						"postMigrations": {
+							"default": null,
 							"scope": "resource",
 							"type": "object",
 							"description": "If set, post migration scripts will be run after migrations.",
@@ -214,6 +215,7 @@
 						}
 					},
 					"scope": "resource",
+					"default": null,
 					"type": "object",
 					"description": "If set, migrations will be applied for all analyses. If the current file is a migration file, execution will run until the previous migration."
 				},


### PR DESCRIPTION
### What does this PR do?

Fixes default values for settings, which set `{}` instead of undefined and would raise errors if `plpgsqlLanguageServer.migrations` or if `plpgsqlLanguageServer.migrations` was set but not `postMigrations`


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
