### PR TITLE
normalize migration file path

### DIFF
--- a/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
+++ b/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
@@ -209,7 +209,7 @@ async function queryMigrations(
 ): Promise<boolean> {
   for await (const file of files) {
     try {
-      if (document.uri.endsWith(file)) {
+      if (document.uri.endsWith(path.normalize(file))) {
         // allow us to revisit and work on any migration/post-migration file
         logger.info("Stopping migration execution at the current file")
 


### PR DESCRIPTION
### What does this PR do?

Simple fix for migration filename matching if using relative paths, e.g. "./db/migrations" instead of "db/migrations"

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
