### PR TITLE
Verbose migration failure error in query files

### DIFF
--- a/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
+++ b/server/src/postgres/queries/queryFileSyntaxAnalysis.ts
@@ -225,11 +225,11 @@ async function queryMigrations(
 
       await pgClient.query(migration)
     } catch (error: unknown) {
-      const errorMessage = (error as DatabaseError).message
+      const queryError = (error as DatabaseError).message
 
-      logger.error(
-        `Stopping migration execution at ${path.basename(file)}: ${errorMessage}`,
-      )
+      // eslint-disable-next-line max-len
+      const errorMessage = `Stopping migration execution at ${path.basename(file)}: ${queryError}`
+      logger.error(errorMessage)
 
       throw new MigrationError(document, errorMessage)
     }


### PR DESCRIPTION
### What does this PR do?

Show the user what exactly failed. As of now we only got the migration error but without information about it actually being a migration error unless looking at the extension logs, so it's confusing.

Now it's something like:
![image](https://user-images.githubusercontent.com/71724149/204135597-0c536405-0f29-4656-9875-bab3b56e95e1.png)


### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
