### PR TITLE
Fix eslint configuration and update text utility function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,12 +44,6 @@
     "comma-spacing": "error",
     "no-unused-vars": "off",
     "space-before-blocks": "error",
-    "@typescript-eslint/no-implicit-any-catch": [
-      "error",
-      {
-        "allowExplicitAny": true
-      }
-    ],
     "object-curly-spacing": [
       "error",
       "always"

--- a/server/src/utilities/text.ts
+++ b/server/src/utilities/text.ts
@@ -65,7 +65,7 @@ export function findIndexFromBuffer(
 
 export function getPositionFromBuffer(fileText: string, index: uinteger): Position {
   const textLines = Buffer.from(fileText)
-    .slice(0, index)
+    .subarray(0, index)
     .toString()
     .split("\n")
 


### PR DESCRIPTION
### What does this PR do?
- There is a problem that @typescript-eslint/no-implicit-any-catch rule was deprecated in ts4.4 and linter was not working. I fixed it.
- Buffer.slice() was deprecated and I replaced.

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
